### PR TITLE
 Added Help Button To Telemetry Interface

### DIFF
--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -129,6 +129,12 @@ hr
 {
   height: calc(2.25rem + 2px);
 }
+
+.modal-lg 
+{
+  max-width: 80%;
+}
+
 .supsub {position: absolute}
 .subscript {display:block; position:relative; left:5px; top: 23px}
 .superscript {display:block; position:relative; left:5px; top: 7px}

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,9 @@
         <div class="collapse navbar-collapse" id="navbarsExampleDefault">
             <ul class="navbar-nav mr-auto"></ul>
             <div class="form-inline mt-2 mt-md-0">
+                    <button class="btn btn-outline-info help-btn" data-toggle="modal" data-target="#myModal" style="margin-right: 15px;">
+                            Help
+                        </button>
                 <label class="form-check-label" style="margin-right: 15px; color: white;">
                     <input class="form-check-input" type="checkbox" value="telemetry" id="graph-switch">
                     Graph
@@ -72,6 +75,55 @@
             </div>
         </div>
     </nav>
+        <!-- Help Modal -->
+<div id="myModal" class="modal fade" role="dialog">
+    <div class="modal-dialog modal-lg">
+  
+        <div class="modal-content">
+            <div class="modal-header">
+            <h4 class="modal-title">How to Use Telemetry</h4>
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+        </div>
+        <div class="modal-body">
+            <h4>Connecting Your Device</h4>
+            <ol>
+                <li>Connect device to USB port</li>
+                <li>Press "Refresh Devices" on navbar to update list of devices connected</li>
+                <li>Using the dropdown menu next to the connect button, connect to the 
+                    corresponding COM or TTY serial device number and press Connect.</li>
+            </ol>
+            <h4>Serial Frequency Select</h4>
+            <ul>
+                <li>Use this to select which serial speed (baud) you would like to use for your device</li>
+            </ul>
+            <h4>Serial Baud Select</h4>
+            <ul>
+                <li>Baud rates select the rate at which bits are sent and received from Telemetry 
+                to your device.</li>
+                <li> 1 Baud represents one bit of information transferred per second.</li>
+            </ul>
+            <h4>Carriage Return (CR) and New Line (NL) Selectors</h4>
+            <ul> 
+                <li>Having CR checked sends a carriage return command at the end of your string of text.</li>
+                <li>Having NL checked sends a new line command at the end of your string of text.</li>
+            </ul>
+            <h4>Telemetry Selector</h4>
+            <ul>
+                <li>Having Telemetry checked enables the Telemetry features, and allows you to interact with your 
+                    variables in real time.</li>
+            </ul>
+            <h4>Graph Selector</h4>
+            <ul>
+                <li>Having Graph checked enables data sent from your device to be graphed in real time.</li>
+            </ul>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+  
+    </div>
+  </div>
     <div class="container-fluid pt-4" style="height: 100%">
         <div class="row" style="height: 97.5%">
             <main class="col-sm-12 col-md-12 col-lg-5">


### PR DESCRIPTION
The button added presents a modal, which contains information the user can reference if any clarification is needed on what the interface has to offer. A CSS class for the modal was also added to ensure it had the correct width when opened.