### PR TITLE
Add support to launch application with a different port

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -32,6 +32,7 @@ import logging
 import webbrowser
 import sys
 import urllib
+import argparse
 from enum import Enum
 
 log = logging.getLogger('werkzeug')
@@ -280,7 +281,13 @@ def dtr(is_on):
     return SUCCESS
 
 if __name__ == "__main__":
-    port = 5001
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--port', type=int, help='Change port where Telemetry runs', default = 5001)
+    port_args = parser.parse_args()
+    if port_args.port >= 2000 and port_args.port <= 49151:
+      port = int(port_args.port)
+    else:
+      raise Exception("Please pick a port between 2000 and 49151")
     if len(sys.argv) == 2:
         port = sys.argv[1]
     # Open This application's web URL in default browser


### PR DESCRIPTION
To run Telemetry on a different port adding the argument `--port <port number>` will run Telemetry on the listed port. 

Only issue I'm having at the moment is`choices=range(1999, 49152)`. When you input a port not in range the error message for it lists all the available "choices" and I can't figure out how to get around it with a custom error message.