### PR TITLE
Fixing xterm key events

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -273,7 +273,8 @@ $("#serial-send").on("click", () =>
         var cr = (carriage_return_active) ? "1" : "0";
         var nl = (newline_active) ? "1" : "0";
 
-        $.get(`${URL}/write/${payload}/${cr}/${nl}`, function(data)
+        $.get(`${URL}/write/${cr}/${nl}?payload=${encodeURIComponent(key)}`,
+        function(data)
         {
             if(data === SUCCESS)
             {
@@ -345,7 +346,7 @@ $("#clear-cache-modal-open").on("click",() =>
 $("#clear-cache").on("click", () =>
 {
   command_history = [];
-  past_commands = ""; 
+  past_commands = "";
   document.getElementById('command-history').innerHTML = "";
   localStorage.setItem('command_history', JSON.stringify(command_history));
   console.info("CLEARED COMMAND HISTORY AND CACHE");
@@ -857,15 +858,24 @@ $(window).resize(() => {
 });
 
 term.on('key', function (key, ev) {
-    if(ev.code == "Backspace")
+    console.log(key, key.hexEncode(), ev);
+    switch(ev.code)
     {
+      case "Backspace":
         key = "\b";
+        break;
+      case "Home":
+        key = "\x1b7";
+        break;
+      case "End":
+        key = "\x1b8";
+        break;
     }
     if(key == "\r")
     {
         key += "\n";
     }
-    $.get(`${URL}/write/${encodeURIComponent(key)}/0/0`, function(data)
+    $.get(`${URL}/write/0/0?payload=${encodeURIComponent(key)}`, function(data)
     {
         if(data === SUCCESS)
         {
@@ -882,9 +892,21 @@ term.on('linefeed', function (key, ev) {
     console.log("linefeed!");
 });
 
-term.on('data', function (data, ev) {
-    console.log(data);
-});
+String.prototype.hexEncode = function(){
+    var hex, i;
+
+    var result = "";
+    for (i=0; i<this.length; i++) {
+        hex = this.charCodeAt(i).toString(16);
+        result += (hex).slice(-4);
+    }
+
+    return result
+}
+
+// term.on('data', function (data, ev) {
+//     console.log(data, data.hexEncode(), ev);
+// });
 
 window.onload = function()
 {

--- a/telemetry.py
+++ b/telemetry.py
@@ -231,9 +231,10 @@ def serial():
     serial_output = ""
     return payload
 # Serial write string (payload) to serial device
-@app.route('/write/<string:payload>/<int:carriage_return>/<int:newline>')
-def write(payload="", carriage_return=0, newline=0):
+@app.route('/write/<int:carriage_return>/<int:newline>')
+def write(carriage_return=0, newline=0):
     lock.acquire()
+    payload = request.args.get('payload')
     decoded_payload = urllib.unquote(payload).decode("ascii")
 
     cr = ""

--- a/templates/index.html
+++ b/templates/index.html
@@ -183,6 +183,7 @@
                         <option          value="4">Serial 4 Hz</option>
                         <option          value="5">Serial 5 Hz</option>
                         <option         value="10">Serial 10 Hz</option>
+                        <option         value="20">Serial 20 Hz</option>
                     </select>
                     <select class="custom-select mb-2 mr-sm-2 mb-sm-0" id="serial-baud-select">
                         <option            value="110">110 baud</option>


### PR DESCRIPTION
Before this fix, if you typed '.' or the various escape characters, they
would not be transmitted to the server, because they do not evaluate to
a proper uri.

To fix this, the write route has become:
/write/<cr>/<nl>?payload=<insert characters here>

The payload can be anything as long as it is URI encoded. This includes
the arrow keys, control escape codes like CTRL+C etc.

Added support for home and end keys.