### PR TITLE
Fixing xterm ENTER key and font issues

### DIFF
--- a/web-app-resources/term.js
+++ b/web-app-resources/term.js
@@ -6,13 +6,14 @@ let term = new Terminal({
   bellStyle: "sound",
   cursorBlink: true,
   lineHeight: 1,
-  fontFamily: "monospace",
+  fontSize: 18,
+  fontFamily: "Ubuntu Mono, courier-new, courier, monospace",
   scrollback: 1024,
 });
 
 term.on('key', function (key, event) {
   key = (event.code == "Backspace") ? "\b" : key;
-  key = (event.code == "\r") ? "\n" : key;
+  key = (event.code == "Enter") ? "\n" : key;
   serial_extension.postMessage({
     "command": "write",
     "data": key


### PR DESCRIPTION
Pressing enter on xterm should now send a \n character to the serial
device.

Set font size to 18 and set font family to "Ubuntu Mono" in order to fix
text clipping from being offset up and to the right.